### PR TITLE
Release v1.1.0: upgrade to ESP-IDF 5.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 set(IDF_TARGET esp32s3)
+set(PROJECT_VER "v1.1.0")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,32 @@
-# Home Assistant & SenseCAP Indicator
+# SenseCAP Indicator Home Assistant
 
 <p align="left">
-  <a href="https://docs.espressif.com/projects/esp-idf/en/release-v5.1/esp32/">
-    <img src="https://img.shields.io/badge/esp--idf-v5.1-00b202" alt="idf-version">
+  <a href="https://docs.espressif.com/projects/esp-idf/en/release-v5.4/esp32s3/">
+    <img src="https://img.shields.io/badge/esp--idf-v5.4.x-00b202" alt="idf-version">
   </a>
+  <img src="https://img.shields.io/badge/version-v1.1.0-blue" alt="version">
 </p>
 
-The Home Assistant demo is available in two versions:
+This firmware turns the SenseCAP Indicator into a Home Assistant companion panel. It connects to Wi-Fi, publishes the built-in environmental sensors through MQTT, and exposes on-screen controls that can be driven from Home Assistant.
 
-- Has only Home Assistant features, which is this repo.
-- Which includes the indicator_basis example  -> [branch - feat_home_assistant](https://github.com/Seeed-Solution/SenseCAP_Indicator_ESP32/tree/main/examples/indicator_ha)
+## Version
 
-There are three demos that show how the indicator integrates with Home Assistant in three ways:
+- Current firmware: `v1.1.0`
+- Baseline release: `v1.0.0`
+- ESP-IDF: `v5.4.x`
+
+`v1.1.0` upgrades the project from the older ESP-IDF 5.1-era codebase to ESP-IDF 5.4.x and improves the MQTT setup experience. The serial console now includes an `mqtthelp` command with concrete broker, topic, and payload examples.
+
+## Features
 
 - [x] [MQTT](#mqtt)
-- [ ] RESTful API(HTTP)
-- [ ] Websocket 
+- [x] Wi-Fi setup from the device screen
+- [x] MQTT broker configuration from the device screen
+- [x] MQTT broker/client configuration from the serial console
+- [x] Built-in sensor publishing: temperature, humidity, CO2, tVOC
+- [x] Home Assistant control widgets: switches, arc control, slider control
+- [ ] REST API
+- [ ] WebSocket
 
 <figure class="third">
     <img align="left" src="./assets/Home Assistant Data.png" width="240"/>
@@ -27,29 +38,49 @@ There are three demos that show how the indicator integrates with Home Assistant
 
 ## MQTT
 
-The wiki for `MQTT` method is provided: [SenseCAP Indicator - Home Assistant Application Development](https://wiki.seeedstudio.com/SenseCAP_Indicator_Application_Home_Assistant/)
+The MQTT integration uses three fixed topics:
 
-### Features
+| Direction | Topic | Example payload |
+| --- | --- | --- |
+| Device sensor data | `indicator/sensor` | `{"temp":"23.5"}` |
+| Home Assistant control command | `indicator/switch/set` | `{"switch1":1}` |
+| Device control state | `indicator/switch/state` | `{"switch1":1}` |
 
-- [x] Wi-Fi Panel - Connect Wi-Fi via screen
-- [x] Display config - Control the intensity of the screen
-- [x] Home Assistant data - Display Sensor data
-- [x] Home Assistant control - the control widgets
+Supported sensor keys are `temp`, `humidity`, `co2`, and `tvoc`. Supported control keys are `switch1` through `switch8`.
 
-### How to use example
+### Configure MQTT
 
-Please first read the [User Guide](https://wiki.seeedstudio.com/Sensor/SenseCAP/SenseCAP_Indicator/Get_started_with_SenseCAP_Indicator/) of the SenseCAP Indicator Board to learn about its software and hardware information.
+You can configure the MQTT broker in either place:
 
-Here are some simple steps to use.
+- On the device screen: open Settings, choose the MQTT broker page, enter the broker IP address, and confirm. The firmware stores it as `mqtt://<ip>:1883`.
+- From the serial console: use `setmqtt` for full broker/client configuration.
+
+Useful serial commands:
+
+```text
+haconfig
+mqtthelp
+setmqtt -a 192.168.1.10 -c indicator-01 -u mqtt_user -p mqtt_password
+setmqtt --addr mqtt://192.168.1.10:1883
+setmqtt --addr mqtt://broker.emqx.io
+```
+
+After `setmqtt` succeeds, the firmware saves the configuration to NVS and restarts the MQTT client automatically.
+
+The MQTT method is also covered in the Seeed wiki: [SenseCAP Indicator - Home Assistant Application Development](https://wiki.seeedstudio.com/SenseCAP_Indicator_Application_Home_Assistant/).
+
+### Home Assistant Setup
 
 - Step 1: [Install Home Assistant](https://www.home-assistant.io/installation/)
-- Step 2: Install MQTT Broker
-- Step 3: Add MQTT  integration and config
-- Step 4: Modify "configuration.yaml" to add Indicator entity
-- Step 5: Edit Dashboard
+- Step 2: Install or enable an MQTT broker, such as Mosquitto.
+- Step 3: Add the MQTT integration in Home Assistant.
+- Step 4: Configure the Indicator to use the same broker address and credentials.
+- Step 5: Add the entities below to `configuration.yaml`.
+- Step 6: Restart Home Assistant and add the dashboard cards.
 
-Add the following to your "configuration.yaml" file
-```
+Add the following to your `configuration.yaml` file:
+
+```yaml
 # Example configuration.yaml entry
 mqtt:
   sensor:
@@ -145,9 +176,9 @@ mqtt:
 ```
 
 
-Add the following to the raw configuration editor of the dashboard.
+Add the following to the raw configuration editor of the dashboard:
 
-```
+```yaml
 views:
   - title: Indicator device
     icon: ''
@@ -193,9 +224,28 @@ views:
 
 
 
-# Build and Flash
+## Build and Flash
 
-- Run `idf.py -p PORT flash monitor` to build, flash and monitor the project.
+This branch is built with ESP-IDF `v5.4.x`. The local helper script defaults to `/Users/spencer/esp/v5.4.3/esp-idf` when `IDF_PATH` is not already set.
+
+Build:
+
+```bash
+sh build.sh
+```
+
+Flash:
+
+```bash
+. "$HOME/esp/v5.4.3/esp-idf/export.sh"
+idf.py -p PORT -b 460800 flash
+```
+
+Monitor:
+
+```bash
+idf.py -p PORT monitor
+```
 
 (To exit the serial monitor, type ``Ctrl-]``.)
 
@@ -217,7 +267,7 @@ General note: Please avoid folder-names and filenames containing non-ASCII (spec
   [ESP-IDF Get started](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html)
   - Install ESP-IDF on Windows: [Description page](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/windows-setup.html)
   - There's a ESP-related IDE too, made by Espressif, containing ESP-IDF, called Espressif-IDE which is based on Eclipse CDT. [Espressif-IDE](https://github.com/espressif/idf-eclipse-plugin/blob/master/docs/Espressif-IDE.md)
-    - Get the [ESP-IDF offline Windows installer](https://dl.espressif.com/dl/idf-installer/esp-idf-tools-setup-offline-5.1.2.exe?) or [Espressif-IDE Windows installer](https://dl.espressif.com/dl/idf-installer/espressif-ide-setup-2.11.1-with-esp-idf-5.1.2.exe?)
+    - Get an ESP-IDF 5.4.x offline installer or an Espressif-IDE installer that bundles ESP-IDF 5.4.x.
     - Install it on your Windows system accepting all offered options and default settings. This automagically installs Python, git, CMake, etc all at once under C:\Espressif folder.
     - You can start building in command-line from the PowerShell/CMD entries created in the start-menu, but with the help of the included build.bat you can build on a normal commandline too
     - Or you can build the project in the IDE GUI, see 'Usage' section.

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-export IDF_PATH=~/esp/esp-idf
-. $IDF_PATH/export.sh  #get_idf
-rm  -r  build  #mkdir  -p  build  #cd build
-idf.py build  #cmake  -G "Ninja"  ..  -DCMAKE_BUILD_TYPE=Release  #ninja  -j 4
+export IDF_PATH="${IDF_PATH:-$HOME/esp/v5.4.3/esp-idf}"
+. "$IDF_PATH/export.sh"  # get_idf
+rm -rf build
+idf.py build

--- a/components/bsp/src/boards/sensecap_indicator_board.c
+++ b/components/bsp/src/boards/sensecap_indicator_board.c
@@ -43,12 +43,20 @@ static const board_button_t g_btns[] = {
     {BOARD_BTN_ID_USER, 0,      GPIO_NUM_38,    0},
 };
 
+static esp_err_t tca9535_read_input_pins_8(uint8_t *pin_val)
+{
+    uint16_t pins = 0;
+    esp_err_t ret = tca9535_read_input_pins(&pins);
+    *pin_val = (uint8_t)pins;
+    return ret;
+}
+
 static const io_expander_ops_t g_board_lcd_evb_io_expander_ops = {
     .init = tca9535_init,
     .set_direction = tca9535_set_direction,
     .set_level = tca9535_set_level,
     .read_output_pins = NULL,
-    .read_input_pins = tca9535_read_input_pins,
+    .read_input_pins = tca9535_read_input_pins_8,
     .multi_write_start = tca9535_multi_write_start,
     .multi_write_new_level = tca9535_multi_write_new_level,
     .multi_write_end = tca9535_multi_write_end,
@@ -304,4 +312,3 @@ const board_res_desc_t *bsp_board_sensecap_indicator_get_res_desc(void)
 {
     return &g_board_lcd_evb_res;
 }
-

--- a/components/bsp/src/calibration/touch_calibration.c
+++ b/components/bsp/src/calibration/touch_calibration.c
@@ -50,9 +50,9 @@ static bool g_calibrated = false;
 static int (*g_touch_is_pressed)(void) = NULL;
 static esp_err_t (*g_touch_read_rawdata)(uint16_t *x, uint16_t *y) = NULL;
 
-static void lcd_draw_bitmap(int x, int y, int w, int h, void *data)
+static esp_err_t lcd_draw_bitmap(int x, int y, int w, int h, const void *data)
 {
-    bsp_lcd_flush(x, y, x + w, y + h, data);
+    return bsp_lcd_flush(x, y, x + w, y + h, data);
 }
 
 static esp_err_t touch_save_calibration(const void *buf, size_t sz)

--- a/components/bsp/src/peripherals/bsp_lcd.c
+++ b/components/bsp/src/peripherals/bsp_lcd.c
@@ -39,7 +39,7 @@ static void lcd_task(void *args);
 
 #if CONFIG_LCD_LVGL_DIRECT_MODE
 static bool (*lvgl_flush_is_end)(void) = NULL;
-static bool (*lvgl_direct_mode_buf_copy)(void) = NULL;
+static void (*lvgl_direct_mode_buf_copy)(void) = NULL;
 #endif
 
 static void *p_user_data = NULL;
@@ -80,10 +80,14 @@ static esp_err_t screen_clear(uint16_t color)
 
 IRAM_ATTR static bool on_vsync_event(
     esp_lcd_panel_handle_t panel,
-    esp_lcd_rgb_panel_event_data_t *edata,
+    const esp_lcd_rgb_panel_event_data_t *edata,
     void *user_ctx
 )
 {
+    (void) panel;
+    (void) edata;
+    (void) user_ctx;
+
     BaseType_t high_task_awoken = pdFALSE;
 #if CONFIG_LCD_AVOID_TEAR
     xSemaphoreGiveFromISR(trans_ready, &high_task_awoken);
@@ -271,7 +275,7 @@ esp_err_t bsp_lcd_init(void)
 #endif
 
 #if CONFIG_LCD_AVOID_TEAR
-        esp_lcd_rgb_panel_get_frame_buffer(panel_handle, 2, &lcd_buf0, &lcd_buf1);
+        esp_lcd_rgb_panel_get_frame_buffer(panel_handle, 2, (void **)&lcd_buf0, (void **)&lcd_buf1);
         trans_ready = xSemaphoreCreateBinary();
         assert(trans_ready);
         xSemaphoreGive(trans_ready);

--- a/components/i2c_devices/touch_panel/gt911.c
+++ b/components/i2c_devices/touch_panel/gt911.c
@@ -391,7 +391,7 @@ int gt911_pos_read(uint16_t *xpos, uint16_t *ypos)
 {
     u8 key_value = 0;
     struct goodix_point_t points[GTP_MAX_TOUCH_ID];
-    u8 finger_state = gtp_get_points(&g_ts_data, &points, &key_value);
+    u8 finger_state = gtp_get_points(&g_ts_data, points, &key_value);
 
     if (finger_state & 0x0f) {
         *xpos = points[0].x;

--- a/components/i2c_devices/touch_panel/tt21100.c
+++ b/components/i2c_devices/touch_panel/tt21100.c
@@ -55,7 +55,7 @@ esp_err_t tt21100_tp_init(void)
 
     uint16_t reg_val = 0;
     do {
-        tt21100_read(&reg_val, sizeof(reg_val));
+        tt21100_read((uint8_t *)&reg_val, sizeof(reg_val));
         vTaskDelay(pdMS_TO_TICKS(20));
     } while (0x0002 != reg_val);
 
@@ -115,7 +115,7 @@ esp_err_t tt21100_tp_read(void)
     esp_err_t ret_val = ESP_OK;
 
     /* Get report data length */
-    ret_val |= tt21100_read(&data_len, sizeof(data_len));
+    ret_val |= tt21100_read((uint8_t *)&data_len, sizeof(data_len));
     ESP_LOGD(TAG, "Data len : %u", data_len);
 
     /* Read report data if length */

--- a/components/lora/sx126x_sensecap_board.c
+++ b/components/lora/sx126x_sensecap_board.c
@@ -47,7 +47,9 @@ static void expander_io_int(void* arg)
     for(;;) {
         if(xQueueReceive(gpio_evt_queue, &io_num, portMAX_DELAY)) {
             //printf("GPIO[%"PRIu32"] intr, val: %d\n", io_num, gpio_get_level(io_num));
-            (g_dioIrq) (0); //handle irq
+            if (g_dioIrq) {
+                g_dioIrq(0); //handle irq
+            }
         }
     }
 }
@@ -187,7 +189,7 @@ void bsp_sx126x_init(void)
 
 void SX126xIoIrqInit( DioIrqHandler dioIrq )
 {
-    g_dioIrq = (uint32_t *)dioIrq;
+    g_dioIrq = dioIrq;
 
     gpio_config_t io_conf = {};
     io_conf.intr_type = GPIO_INTR_NEGEDGE; //falling edge
@@ -249,7 +251,7 @@ void SX126xReset( void )
 
 void SX126xWaitOnBusy( void )
 {
-    uint16_t pin_val;
+    uint8_t pin_val;
     while(1) {
         esp_err_t ret = p_io_expander->read_input_pins(&pin_val);
         if( ret == ESP_OK ) {
@@ -425,7 +427,7 @@ bool SX126xCheckRfFrequency( uint32_t frequency )
 
 uint32_t SX126xGetDio1PinState( void )
 {
-    uint16_t pin_val;
+    uint8_t pin_val;
     esp_err_t ret = p_io_expander->read_input_pins(&pin_val);
     if( ret == ESP_OK ) {
         if( (pin_val & (0x01 << EXPANDER_IO_RADIO_DIO_1)) ) {
@@ -434,4 +436,3 @@ uint32_t SX126xGetDio1PinState( void )
     }
     return 0;
 }
-

--- a/main/app/esp32_rp2040.c
+++ b/main/app/esp32_rp2040.c
@@ -15,6 +15,7 @@
 // #include "time.h"
 #include "view_data.h"
 #include <stdlib.h>
+#include <string.h>
 
 static const char* TAG = "esp32_rp2040";
 

--- a/main/app/indicator_btn.c
+++ b/main/app/indicator_btn.c
@@ -2,6 +2,7 @@
 #include "bsp_btn.h"
 #include "esp_timer.h"
 #include <nvs.h>
+#include <nvs_flash.h>
 
 static uint32_t hold_cnt = 0;
 static bool sleep_flag = false;

--- a/main/app/indicator_cmd.c
+++ b/main/app/indicator_cmd.c
@@ -2,6 +2,7 @@
 #include "argtable3/argtable3.h"
 #include "esp_console.h"
 
+#include "home_assistant_config.h"
 #include "indicator_ha.h"
 #include "indicator_storage_nvs.h"
 #include "indicator_util.h"
@@ -20,14 +21,62 @@ esp_event_loop_handle_t cmd_cfg_event_handle;
 
 static ha_cfg_interface ha_cfg;
 
+static void print_mqtt_usage(void)
+{
+    printf("\nMQTT configuration\n");
+    printf("  Show current config:\n");
+    printf("    haconfig\n\n");
+    printf("  Set broker, client id and credentials:\n");
+    printf("    setmqtt -a 192.168.1.10 -c indicator-01 -u mqtt_user -p mqtt_password\n");
+    printf("    setmqtt --addr mqtt://192.168.1.10:1883\n");
+    printf("    setmqtt --addr mqtt://broker.emqx.io\n\n");
+    printf("  Notes:\n");
+    printf("    - The screen MQTT page only asks for the broker IP. It builds mqtt://<ip>:1883.\n");
+    printf("    - Restart is automatic after setmqtt succeeds.\n\n");
+    printf("MQTT topics and payloads\n");
+    printf("  Sensor data from device:\n");
+    printf("    topic: %s\n", CONFIG_TOPIC_SENSOR_DATA);
+    printf("    data : {\"temp\":\"23.5\"}, {\"humidity\":\"55\"}, {\"co2\":\"600\"}, {\"tvoc\":\"12\"}\n\n");
+    printf("  Control device from Home Assistant/MQTT client:\n");
+    printf("    topic: %s\n", CONFIG_TOPIC_SWITCH_SET);
+    printf("    data : {\"switch1\":1}, {\"switch1\":0}, {\"switch5\":24}, {\"switch8\":50}\n\n");
+    printf("  Device publishes control state:\n");
+    printf("    topic: %s\n", CONFIG_TOPIC_SWITCH_STATE);
+    printf("    data : {\"switch1\":1}, {\"switch5\":24}, {\"switch8\":50}\n\n");
+}
+
+static bool normalize_broker_url(const char *input, char *output, size_t output_size)
+{
+    if (!input || input[0] == '\0' || !output || output_size == 0) {
+        return false;
+    }
+
+    int written = 0;
+    if (strncmp(input, "mqtt://", 7) == 0 || strncmp(input, "mqtts://", 8) == 0) {
+        written = snprintf(output, output_size, "%s", input);
+    } else {
+        written = snprintf(output, output_size, "mqtt://%s", input);
+    }
+
+    return written > 0 && (size_t)written < output_size;
+}
+
 // Function to read and display the current contents of ha_cfg
 static int read_ha_config(int argc, char **argv)
 {
+    ha_cfg_get(&ha_cfg);
     ESP_LOGI(TAG, "| Broker Address               | %-40s |", ha_cfg.broker_url);
     ESP_LOGI(TAG, "| Client ID                    | %-40s |", ha_cfg.client_id);
     ESP_LOGI(TAG, "| MQTT username                | %-40s |", ha_cfg.username);
     ESP_LOGI(TAG, "| MQTT password                | %-40s |", ha_cfg.password);
+    ESP_LOGI(TAG, "Run 'mqtthelp' for setmqtt examples and MQTT topic/payload examples.");
 
+    return 0;
+}
+
+static int mqtt_help(int argc, char **argv)
+{
+    print_mqtt_usage();
     return 0;
 }
 
@@ -36,9 +85,20 @@ static void register_read_config(void)
 {
     const esp_console_cmd_t cmd = {
         .command = "haconfig",
-        .help    = "Read and display current configuration",
+        .help    = "Show current MQTT broker/client configuration",
         .hint    = NULL,
         .func    = &read_ha_config,
+    };
+    ESP_ERROR_CHECK(esp_console_cmd_register(&cmd));
+}
+
+static void register_mqtt_help(void)
+{
+    const esp_console_cmd_t cmd = {
+        .command = "mqtthelp",
+        .help    = "Show MQTT setup examples, topics and payloads",
+        .hint    = NULL,
+        .func    = &mqtt_help,
     };
     ESP_ERROR_CHECK(esp_console_cmd_register(&cmd));
 }
@@ -58,6 +118,7 @@ static int mqtt_config_set(int argc, char **argv)
 
     if (nerrors != 0) {
         arg_print_errors(stderr, mqtt_args.end, argv[0]);
+        print_mqtt_usage();
         return 1;
     }
 
@@ -65,11 +126,11 @@ static int mqtt_config_set(int argc, char **argv)
         !mqtt_args.password->count &&
         !mqtt_args.broker_url->count &&
         !mqtt_args.client_id->count) {
-        // None of the relevant arguments are provided
-        // ESP_LOGI(TAG, "No MQTT configuration arguments provided.");
-        return 0; // Exit without updating configuration
+        print_mqtt_usage();
+        return 0;
     }
 
+    ha_cfg_get(&ha_cfg);
 
     if (mqtt_args.username->count > 0) {
         memset(ha_cfg.username, 0, sizeof(ha_cfg.username));
@@ -84,34 +145,14 @@ static int mqtt_config_set(int argc, char **argv)
     }
 
     if (mqtt_args.broker_url->count > 0) {
-        char *url = mqtt_args.broker_url->sval[0];
-
-        // Check if "mqtt://" is not already present
-        if (strncmp(url, "mqtt://", 7) != 0) {
-            char modified_url[128]; // Adjust the size as needed
-
-            // Add "mqtt://" to the beginning of the URL
-            snprintf(modified_url, sizeof(modified_url), "mqtt://%s", url);
-
-            // Check if the modified URL is valid
-            if (is_valid_ipv4(modified_url + 7)) {
-                memset(ha_cfg.broker_url, 0, sizeof(ha_cfg.broker_url));
-                strncpy(ha_cfg.broker_url, modified_url, sizeof(ha_cfg.broker_url) - 1);
-                ESP_LOGI(TAG, "Set MQTT broker URL: %s", ha_cfg.broker_url);
-            } else {
-                ESP_LOGE(TAG, "Invalid broker URL: %s", modified_url);
-            }
-        } else {
-            // "mqtt://" is already present
-            // Check if the URL is valid
-            if (is_valid_ipv4(url + 7)) {
-                memset(ha_cfg.broker_url, 0, sizeof(ha_cfg.broker_url));
-                strncpy(ha_cfg.broker_url, url, sizeof(ha_cfg.broker_url) - 1);
-                ESP_LOGI(TAG, "Set MQTT broker URL: %s", ha_cfg.broker_url);
-            } else {
-                ESP_LOGE(TAG, "Invalid broker URL: %s", url);
-            }
+        char broker_url[sizeof(ha_cfg.broker_url)];
+        if (!normalize_broker_url(mqtt_args.broker_url->sval[0], broker_url, sizeof(broker_url))) {
+            ESP_LOGE(TAG, "Invalid or too long broker URL: %s", mqtt_args.broker_url->sval[0]);
+            return 1;
         }
+        memset(ha_cfg.broker_url, 0, sizeof(ha_cfg.broker_url));
+        strncpy(ha_cfg.broker_url, broker_url, sizeof(ha_cfg.broker_url) - 1);
+        ESP_LOGI(TAG, "Set MQTT broker URL: %s", ha_cfg.broker_url);
     }
 
     if (mqtt_args.client_id->count > 0) {
@@ -120,8 +161,12 @@ static int mqtt_config_set(int argc, char **argv)
         ESP_LOGI(TAG, "Set MQTT client ID: %s", ha_cfg.client_id);
     }
     // Save the updated configuration to NVS, then alert, don't need to transport configuration.
-    ha_cfg_set(&ha_cfg);
-    esp_event_post_to(ha_cfg_event_handle, HA_CFG_EVENT_BASE, HA_CFG_SET, NULL, NULL, portMAX_DELAY);
+    if (ha_cfg_set(&ha_cfg) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to save MQTT configuration");
+        return 1;
+    }
+    esp_event_post_to(ha_cfg_event_handle, HA_CFG_EVENT_BASE, HA_CFG_SET, NULL, 0, portMAX_DELAY);
+    ESP_LOGI(TAG, "MQTT configuration saved. Reconnecting MQTT client.");
 
     return 0;
 }
@@ -131,13 +176,13 @@ static void register_mqtt_config(void)
 {
     mqtt_args.username          = arg_str0("u", "usr", "<username>", "MQTT username");
     mqtt_args.password          = arg_str0("p", "psw", "<password>", "MQTT password");
-    mqtt_args.broker_url        = arg_str0("a", "addr", "<broker_url>", "MQTT broker URL");
+    mqtt_args.broker_url        = arg_str0("a", "addr", "<broker_url>", "MQTT broker URL, e.g. 192.168.1.10 or mqtt://host:1883");
     mqtt_args.client_id         = arg_str0("c", "id", "<client_id>", "MQTT client ID");
     mqtt_args.end               = arg_end(4);
 
     const esp_console_cmd_t cmd = {
         .command  = "setmqtt",
-        .help     = "Set MQTT configuration",
+        .help     = "Set MQTT config. Example: setmqtt -a 192.168.1.10 -c indicator-01 -u user -p pass",
         .hint     = NULL,
         .func     = &mqtt_config_set,
         .argtable = &mqtt_args,
@@ -167,6 +212,7 @@ int indicator_cmd_init(void)
 
     ha_cfg_get(&ha_cfg);
     register_read_config();
+    register_mqtt_help();
     // register_set_broker_url();
     // register_mqtt_credentials();
     register_mqtt_config();

--- a/main/app/indicator_display_model.c
+++ b/main/app/indicator_display_model.c
@@ -1,8 +1,10 @@
 #include "indicator_display.h"
+#include "indicator_storage_nvs.h"
 
 #include "freertos/semphr.h"
 
 #include <nvs.h>
+#include <string.h>
 #include "driver/ledc.h"
 #include "esp_timer.h"
 

--- a/main/app/indicator_ha_view.c
+++ b/main/app/indicator_ha_view.c
@@ -1,6 +1,7 @@
 #include "core/lv_obj.h"
 #include "extra/widgets/msgbox/lv_msgbox.h"
 #include "indicator_ha.h"
+#include "lv_port.h"
 #include "misc/lv_anim.h"
 #include "view_data.h"
 #include "ui.h"
@@ -195,5 +196,4 @@ int indicator_ha_view_init(void) {
 	ESP_ERROR_CHECK(esp_event_handler_instance_register_with(
 		view_event_handle, VIEW_EVENT_BASE, VIEW_EVENT_HA_ADDR_DISPLAY, __view_event_handler, NULL, NULL));
 }
-
 

--- a/main/app/indicator_mqtt.h
+++ b/main/app/indicator_mqtt.h
@@ -14,7 +14,6 @@
 
 #include "nvs.h"
 #include "view_data.h"
-#include "config.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 #include "freertos/semphr.h"
@@ -48,8 +47,9 @@ typedef struct {
  * 
  * Send instance_mqtt to __app_event_handler
  */
-typedef void (*MQTTStartFn)(struct instance_mqtt_t *instance); // Example function taking an int and returning void
-typedef struct instance_mqtt {
+typedef struct instance_mqtt instance_mqtt;
+typedef void (*MQTTStartFn)(instance_mqtt *instance); // Example function taking an int and returning void
+struct instance_mqtt {
     char                     *mqtt_name;
     bool                      mqtt_connected_flag;
     esp_mqtt_client_handle_t  mqtt_client; // point
@@ -57,7 +57,8 @@ typedef struct instance_mqtt {
     esp_event_handler_t       mqtt_event_handler;
     MQTTStartFn               mqtt_starter;
     bool                      is_using;
-} instance_mqtt, *instance_mqtt_t;
+};
+typedef instance_mqtt *instance_mqtt_t;
 
 /* Functions */
 

--- a/main/app/indicator_sensor_view.c
+++ b/main/app/indicator_sensor_view.c
@@ -1,5 +1,6 @@
 #include "indicator_sensor.h"
 
+#include "lv_port.h"
 #include "ui.h"
 #include "view_data.h"
 
@@ -101,16 +102,16 @@ void view_sensor_init() {
 	sensorPanel[SCD41_SENSOR_CO2].ui_lbl[0] = ui_sensor_data_co2_2;
 
 	sensorPanel[SGP40_SENSOR_TVOC].ui_lbl_size = 1;
-	sensorPanel[SGP40_SENSOR_TVOC].ui_lbl = (lv_obj_t*)malloc(sizeof(lv_obj_t*) * 1);
+	sensorPanel[SGP40_SENSOR_TVOC].ui_lbl = (lv_obj_t**)malloc(sizeof(lv_obj_t*) * 1);
 	sensorPanel[SGP40_SENSOR_TVOC].ui_lbl[0] = ui_sensor_data_tvoc_2;
 
 	sensorPanel[SHT41_SENSOR_TEMP].ui_lbl_size = 2;
-	sensorPanel[SHT41_SENSOR_TEMP].ui_lbl = (lv_obj_t*)malloc(sizeof(lv_obj_t*) * 1);
+	sensorPanel[SHT41_SENSOR_TEMP].ui_lbl = (lv_obj_t**)malloc(sizeof(lv_obj_t*) * 2);
 	sensorPanel[SHT41_SENSOR_TEMP].ui_lbl[0] = ui_sensor_data_temp_1;
 	sensorPanel[SHT41_SENSOR_TEMP].ui_lbl[1] = ui_sensor_data_temp_2;
 
 	sensorPanel[SHT41_SENSOR_HUMIDITY].ui_lbl_size = 2;
-	sensorPanel[SHT41_SENSOR_HUMIDITY].ui_lbl = (lv_obj_t*)malloc(sizeof(lv_obj_t*) * 1);
+	sensorPanel[SHT41_SENSOR_HUMIDITY].ui_lbl = (lv_obj_t**)malloc(sizeof(lv_obj_t*) * 2);
 	sensorPanel[SHT41_SENSOR_HUMIDITY].ui_lbl[0] = ui_sensor_data_humi_1;
 	sensorPanel[SHT41_SENSOR_HUMIDITY].ui_lbl[1] = ui_sensor_data_humi_2;
 

--- a/main/app/indicator_wifi.h
+++ b/main/app/indicator_wifi.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 int indicator_wifi_model_init(void);
-// int indicator_wifi_view_init(void);
+int indicator_wifi_view_init(void);
 
 #ifdef __cplusplus
 }

--- a/main/app/indicator_wifi_view.c
+++ b/main/app/indicator_wifi_view.c
@@ -1,4 +1,5 @@
 #include "indicator_wifi.h"
+#include "indicator_util.h"
 #include "lv_port.h"
 #include "ui.h"
 
@@ -486,7 +487,7 @@ static void __view_event_handler(void* handler_args, esp_event_base_t base, int3
 			ESP_LOGI(TAG, "event: VIEW_EVENT_WIFI_ST | update wifi signal icon");
 			struct view_data_wifi_st* p_st = (struct view_data_wifi_st*)event_data;
 
-			uint8_t* p_src = NULL;
+			const void* p_src = NULL;
 			// todo is_network
 			if(p_st->is_connected)
 			{
@@ -550,7 +551,7 @@ static void __view_event_handler(void* handler_args, esp_event_base_t base, int3
 
 			if(p_list->is_connect)
 			{
-				create_wifi_item(ui_wifi_list, p_list->connect.ssid, p_list->connect.auth_mode, p_list->connect.ssid,
+				create_wifi_item(ui_wifi_list, p_list->connect.ssid, p_list->connect.auth_mode, p_list->connect.rssi,
 								 true);
 			}
 			for(int i = 0; i < p_list->cnt; i++)

--- a/main/indicator_view.c
+++ b/main/indicator_view.c
@@ -1,5 +1,6 @@
 #include "indicator_enabler.h"
 
+#include "lv_port.h"
 #include "ui.h"
 #include "view_data.h"
 

--- a/main/lv_port.c
+++ b/main/lv_port.c
@@ -35,7 +35,7 @@ static TaskHandle_t lvgl_task_handle;
 
 static void lv_port_disp_init(void);
 static void lv_port_indev_init(void);
-static bool lv_port_flush_ready(void);
+static bool lv_port_flush_ready(void *data);
 static bool lv_port_flush_is_last(void);
 static IRAM_ATTR void touchpad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data);
 static void disp_flush(lv_disp_drv_t *disp_drv, const lv_area_t *area, lv_color_t *color_p);
@@ -76,8 +76,10 @@ void lv_port_sem_give(void)
  * @return true Call `portYIELD_FROM_ISR()` after esp-lcd ISR return.
  * @return false Do nothing after esp-lcd ISR return.v
  */
-static bool lv_port_flush_ready(void)
+static bool lv_port_flush_ready(void *data)
 {
+    (void)data;
+
     /* Inform the graphics library that you are ready with the flushing */
     lv_disp_flush_ready(&disp_drv);
 

--- a/main/main.c
+++ b/main/main.c
@@ -21,7 +21,7 @@
 #include "lv_port.h"
 #include "ui/ui.h"
 
-#define VERSION		 "v1.0.0"
+#define VERSION		 "v1.1.0"
 #define LOG_MEM_INFO 1
 #define SENSECAP \
 	"\n\

--- a/main/ui/screens/ui_screen_broker.c
+++ b/main/ui/screens/ui_screen_broker.c
@@ -82,7 +82,7 @@ void ui_screen_broker_screen_init(void)
     lv_obj_set_x(ui_Label3, -13);
     lv_obj_set_y(ui_Label3, -60);
     lv_obj_set_align(ui_Label3, LV_ALIGN_CENTER);
-    lv_label_set_text(ui_Label3, "Home Assistant address");
+    lv_label_set_text(ui_Label3, "MQTT Broker IP");
 
     ui_textarea_ip_0 = lv_textarea_create(ui_container_Inputer);
     lv_obj_set_width(ui_textarea_ip_0, 155);
@@ -93,7 +93,7 @@ void ui_screen_broker_screen_init(void)
     if("0123456789." == "") lv_textarea_set_accepted_chars(ui_textarea_ip_0, NULL);
     else lv_textarea_set_accepted_chars(ui_textarea_ip_0, "0123456789.");
     lv_textarea_set_max_length(ui_textarea_ip_0, 20);
-    lv_textarea_set_placeholder_text(ui_textarea_ip_0, "192.168.1.1");
+    lv_textarea_set_placeholder_text(ui_textarea_ip_0, "192.168.1.10");
     lv_textarea_set_one_line(ui_textarea_ip_0, true);
 
 

--- a/main/ui/ui_events.c
+++ b/main/ui/ui_events.c
@@ -80,5 +80,5 @@ void ui_event_wifi_start(lv_event_t* e) {
 
 void mqtt_addr_changed(lv_event_t* e) {
 	ESP_LOGI(TAG, "addr button comfirmed");
-	esp_event_post_to(view_event_handle, VIEW_EVENT_BASE, VIEW_EVENT_MQTT_ADDR_CHANGED, NULL, NULL, portMAX_DELAY);
+	esp_event_post_to(view_event_handle, VIEW_EVENT_BASE, VIEW_EVENT_MQTT_ADDR_CHANGED, NULL, 0, portMAX_DELAY);
 }

--- a/main/ui/ui_helpers.c
+++ b/main/ui/ui_helpers.c
@@ -25,7 +25,7 @@ void _ui_dropdown_set_property(lv_obj_t * target, int id, int val)
     if(id == _UI_DROPDOWN_PROPERTY_SELECTED) lv_dropdown_set_selected(target, val);
 }
 
-void _ui_image_set_property(lv_obj_t * target, int id, uint8_t * val)
+void _ui_image_set_property(lv_obj_t * target, int id, const void * val)
 {
     if(id == _UI_IMAGE_PROPERTY_IMAGE) lv_img_set_src(target, val);
 }
@@ -345,5 +345,4 @@ void _ui_switch_theme(int val)
     ui_theme_set(val);
 #endif
 }
-
 

--- a/main/ui/ui_helpers.h
+++ b/main/ui/ui_helpers.h
@@ -27,7 +27,7 @@ void _ui_basic_set_property(lv_obj_t * target, int id, int val);
 void _ui_dropdown_set_property(lv_obj_t * target, int id, int val);
 
 #define _UI_IMAGE_PROPERTY_IMAGE 0
-void _ui_image_set_property(lv_obj_t * target, int id, uint8_t * val);
+void _ui_image_set_property(lv_obj_t * target, int id, const void * val);
 
 #define _UI_LABEL_PROPERTY_TEXT 0
 void _ui_label_set_property(lv_obj_t * target, int id, const char * val);

--- a/main/util/indicator_util.c
+++ b/main/util/indicator_util.c
@@ -2,6 +2,8 @@
 #include <esp_system.h>
 #include <esp_log.h>
 #include <regex.h>
+#include <stdio.h>
+#include <string.h>
 
 static const char* TAG = "indicator-utils";
 


### PR DESCRIPTION
## Summary

- Upgrade the firmware build path to ESP-IDF 5.4.x and set project/app version to v1.1.0.
- Fix ESP-IDF 5.4 compatibility issues across BSP, LCD, touch, LoRa, LVGL, MQTT, Wi-Fi, and UI code.
- Improve MQTT setup guidance with a new serial `mqtthelp` command, clearer `setmqtt` examples, and a clearer device UI label.
- Refresh README for v1.1.0, ESP-IDF 5.4.x, MQTT topics, payloads, and build/flash flow.

## Verification

- `sh build.sh` passes with ESP-IDF 5.4.3.
- Firmware flashed successfully to ESP32-S3 on `/dev/cu.usbserial-1110`.
- GitHub releases created for `v1.0.0` and `v1.1.0`; v1.1.0 includes the firmware zip asset.
