### PR TITLE
docs(ha): document how to wire VIEW_EVENT_HA_SENSOR to the HA Mix cards

### DIFF
--- a/main/ha/ha_sensor.c
+++ b/main/ha/ha_sensor.c
@@ -117,6 +117,22 @@ int ha_sensor_on_mqtt_data(const char *topic, int topic_len, const char *data, i
                 strncpy(sensor_data.value, cjson_item->valuestring, sizeof(sensor_data.value) - 1);
 
                 ESP_LOGI(TAG, "MQTT message: sensor %s is %s", ha_sensor_entities[i].key, sensor_data.value);
+                /*
+                 * NOTE: VIEW_EVENT_HA_SENSOR currently has NO consumer, so this
+                 * value is parsed and posted but never shown. Wiring it up turns
+                 * the Indicator into a generic HA dashboard: display ANY entity
+                 * pushed from Home Assistant over MQTT, with no physical sensor
+                 * attached to the device (the use case in issue #5).
+                 *
+                 * To wire it up:
+                 *   1. ha_switch_screen.c::_create_sensor_card already builds the
+                 *      "N/A" data labels on NAV_TILE_HA_MIX but discards the handle.
+                 *      Store each label keyed by card index (cf. the switch_slot_t
+                 *      pattern).
+                 *   2. Register a VIEW_EVENT_HA_SENSOR handler that, under the LVGL
+                 *      lock, does lv_label_set_text(labels[data->index], data->value).
+                 *   3. Make sensor_data.index here map to the intended card slot.
+                 */
                 esp_event_post_to(view_event_handle, VIEW_EVENT_BASE, VIEW_EVENT_HA_SENSOR, &sensor_data, sizeof(sensor_data), portMAX_DELAY);
                 cJSON_Delete(root);
                 return 0;

--- a/main/ha/ha_switch_screen.c
+++ b/main/ha/ha_switch_screen.c
@@ -268,6 +268,13 @@ static void _create_sensor_card(lv_obj_t *tile, const sensor_card_spec_t *spec)
     lv_obj_add_flag(icon, LV_OBJ_FLAG_ADV_HITTEST);
     lv_obj_remove_flag(icon, LV_OBJ_FLAG_SCROLLABLE);
 
+    /*
+     * This "N/A" label is the display slot for HA-pushed sensor values
+     * (VIEW_EVENT_HA_SENSOR). Its handle is currently discarded, so the card
+     * stays "N/A". To make it live, store `data` keyed by card index and have a
+     * VIEW_EVENT_HA_SENSOR handler call lv_label_set_text on it. See the wiring
+     * note in ha_sensor.c (ha_sensor_on_mqtt_data).
+     */
     lv_obj_t *data = lv_label_create(card);
     lv_obj_set_size(data, 100, LV_SIZE_CONTENT);
     lv_obj_set_pos(data, spec->data_x, spec->data_y);


### PR DESCRIPTION
## What

Adds cross-referencing code comments at the two anchor points for the unwired **HA-pushed sensor display** flow (`VIEW_EVENT_HA_SENSOR`). No behavior change — comments only.

## Why

`VIEW_EVENT_HA_SENSOR` is posted by `ha_sensor.c::ha_sensor_on_mqtt_data()` when incoming MQTT sensor JSON arrives, but it has **no registered consumer**, so those values are parsed and silently dropped. The display slots already exist: `ha_switch_screen.c::_create_sensor_card` builds the `"N/A"` labels on `NAV_TILE_HA_MIX` but discards the label handle.

Wiring this flow up would turn the Indicator into a generic HA dashboard — display **any** Home Assistant entity over MQTT with no physical sensor attached to the device. That's the actual need behind closed issue #5.

These comments document the ~3-step wiring at the exact code sites so whoever picks it up doesn't have to re-discover the two data flows. (Background also captured in `main/ha/README.md`.)

## Changes

- `main/ha/ha_sensor.c` — note at the `esp_event_post_to(VIEW_EVENT_HA_SENSOR, ...)` site.
- `main/ha/ha_switch_screen.c` — note at the orphaned `"N/A"` data label in `_create_sensor_card`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)