### PR TITLE
fix(wifi): use opaque modal backdrop to stop LVGL render freeze

### DIFF
--- a/main/wifi/wifi_connect_screen.c
+++ b/main/wifi/wifi_connect_screen.c
@@ -116,7 +116,7 @@ wifi_connect_screen_t *wifi_connect_screen_show(const char *ssid, bool have_pass
     strncpy(s->ssid, ssid, sizeof(s->ssid));
 
     lv_obj_add_flag(lv_layer_top(), LV_OBJ_FLAG_CLICKABLE);
-    lv_obj_set_style_bg_opa(lv_layer_top(), LV_OPA_50, 0);
+    lv_obj_set_style_bg_opa(lv_layer_top(), LV_OPA_COVER, 0);
     lv_obj_set_style_bg_color(lv_layer_top(), lv_palette_main(LV_PALETTE_GREY), 0);
 
     s->container = lv_obj_create(lv_layer_top());
@@ -192,7 +192,7 @@ wifi_connect_screen_t *wifi_details_screen_show(const char *ssid) {
     strncpy(s->ssid, ssid, sizeof(s->ssid));
 
     lv_obj_add_flag(lv_layer_top(), LV_OBJ_FLAG_CLICKABLE);
-    lv_obj_set_style_bg_opa(lv_layer_top(), LV_OPA_50, 0);
+    lv_obj_set_style_bg_opa(lv_layer_top(), LV_OPA_COVER, 0);
     lv_obj_set_style_bg_color(lv_layer_top(), lv_palette_main(LV_PALETTE_GREY), 0);
 
     s->container = lv_obj_create(lv_layer_top());


### PR DESCRIPTION
## What

The Wi-Fi **connect** and **details** dialogs (`main/wifi/wifi_connect_screen.c`) dimmed the background by setting a **50% translucent** background on `lv_layer_top()`. This change makes both backdrops **opaque** (`LV_OPA_50` → `LV_OPA_COVER`).

## Why

A translucent top layer forces LVGL to composite the **entire 480×480 screen** through an intermediate buffer every frame. With `CONFIG_LCD_LVGL_FULL_REFRESH=y` (this board's default, required to avoid tearing), the invalidated area is the whole screen, so each refresh allocates **and frees a ~450 KB layer buffer** from PSRAM via TLSF.

That alloc/free churn pushes a single refresh past the **5 s task watchdog**, wedging `taskLVGL`:

```
task_wdt: ... CPU 1: taskLVGL
Backtrace: ... lv_display_refr_timer -> draw_buf_flush -> lv_draw_dispatch
           -> lv_draw_layer_alloc_buf -> lv_draw_buf_create -> lv_free -> lv_tlsf_free
```

Symptom on hardware: the moment you open the Wi-Fi password dialog the **display glitches and touch stops responding**, so credentials can never be saved. The home/sensor screens are unaffected because they have no translucent full-screen layer.

## Fix

Switch both dialogs to `LV_OPA_COVER`. This matches the project's own convention in [`AGENTS.md`](AGENTS.md) and **every other modal** (`wifi_view.c`, `display_view.c`, `settings_view.c`, `ha_config.c`), all of which already use `LV_OPA_COVER`. `wifi_connect_screen.c` was the lone exception. The backdrop is now a solid dim instead of see-through, and the render path no longer allocates a per-frame layer buffer.

## Testing

Built with ESP-IDF v5.4.4 and flashed to a SenseCAP Indicator (ESP32-S3). Before: continuous `taskLVGL` watchdog every 5 s on the password screen. After: **0 watchdog hits**, password dialog renders smoothly, Wi-Fi join completes, and MQTT connects/subscribes to the broker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)